### PR TITLE
Add an alternative font to h2 element

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
          }
 
          h2 {
-            font-family: Lobster;
+            font-family: Lobster, monospace;
          }
 
          p {


### PR DESCRIPTION
The Lobster font was imported from Google Font Libraries.
But, if the import link is missing and the specified font is not instaled on the system,
the browser will show the second specified font, in this case, monospace.