### PR TITLE
Turn the border corners round

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,6 +23,7 @@
             border-color: green;
             border-width: 10px;
             border-style: solid;
+            border-radius: 10px;
          }
 
          .smaller-image {


### PR DESCRIPTION
The CSS property 'border-radius' was added to the 'thick-green-border' class, turning the border corners round