### PR TITLE
Change blue-box and red-box classes margin

### DIFF
--- a/box.html
+++ b/box.html
@@ -20,14 +20,14 @@
           background-color: crimson;
           color: #fff;
           padding: 20px;
-          margin: 20px;
+          margin: -15px;
         }
       
         .blue-box {
           background-color: blue;
           color: #fff;
           padding: 20px;
-          margin: 20px;
+          margin: -15px;
         }
       </style>
       <h5 class="injected-text">margin</h5>


### PR DESCRIPTION
Both red and blue-box classes margins was changed to a negetive value, causing both to fill the entire horizontal width of the yellow box arround it