### PR TITLE
Change the re-box class padding property

### DIFF
--- a/box.html
+++ b/box.html
@@ -19,7 +19,7 @@
         .red-box {
           background-color: crimson;
           color: #fff;
-          padding: 40px 20px 20px 40px;
+          padding: 1.5em;
           margin: 40px 20px 20px 40px;
         }
       


### PR DESCRIPTION
The padding of red-box was changed from px(pixels) to a relative lenght unity: 'em' that is based on the size of the elements font.